### PR TITLE
Missmatch in function return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 build/
+.idea

--- a/src/Struct/Generic/JobHandle.php
+++ b/src/Struct/Generic/JobHandle.php
@@ -127,6 +127,6 @@ class JobHandle implements JobHandleInterface
      */
     public function getResultChunks(): int
     {
-        return $this->resultChunks;
+        return intval($this->resultChunks);
     }
 }


### PR DESCRIPTION
Function returs string instead of integer value.