### PR TITLE
Deprecated erroneous methods in FormStatistic

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -317,6 +317,7 @@ MailingConfiguration(
     string <salutationCompany>
     string <salutationFamily>
     string <salutationOther>
+    string <salutationDivers>
     string <senderEmail>
     string <senderName>
     string <replyName>
@@ -588,20 +589,45 @@ SmartLink(
 ```
 ##### SmartLinkConfiguration
 Represents a smart link configuration element.<br>
-
+ 
 ```
 SmartLinkConfiguration(
     int <id>
     string <targetUrl>
     bool <individualScoringConfig>
-    int restrictionTargetGroupId
-    array restrictionUserAgents
-    int milestoneId
-    bool activateRedirect
-    bool activateProfileUpdate
-    bool activateTracking
-    array(SmartLinkScoringConfiguration) scoringConfigs
-    array(SmartLinkPoolConfiguration) poolAttributes
+    int <restrictionTargetGroupId>
+    array <restrictionUserAgents>
+    int <milestoneId>
+    bool <activateRedirect>
+    bool <activateProfileUpdate>
+    bool <activateTracking>
+    array <scoringConfigs>
+    array <poolAttributes>
+)
+```
+##### SmartLinkPoolConfiguration
+Represents a smart link pool configuration element.<br>
+ 
+```
+SmartLinkPoolConfiguration(
+    int <id>
+    int <poolId>
+    int <poolAttributeId>
+    string <value>
+    bool <isMerge>
+)
+```
+##### SmartLinkScoringConfiguration
+Represents a smart link scoring configuration element.<br>
+ 
+```
+SmartLinkScoringConfiguration(
+    int <id>
+    string <name>
+    int <value>
+    int <multipleScoreTimeThreshold>
+    int <scoringGroupId>
+    int <type>
 )
 ```
 ### Statistic

--- a/src/Struct/Statistic/FormStatistic.php
+++ b/src/Struct/Statistic/FormStatistic.php
@@ -142,34 +142,42 @@ class FormStatistic implements FormStatisticInterface
 
     /**
      * @return string
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getUrl(): string
     {
-        return $this->url;
+        return (string) $this->url;
     }
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getTypeId(): int
     {
-        return $this->typeId;
+        return (int) $this->typeId;
     }
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getFolderId(): int
     {
-        return $this->folderId;
+        return (int) $this->folderId;
     }
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getMandatorId(): int
     {
-        return $this->mandatorId;
+        return (int) $this->mandatorId;
     }
 
     /**

--- a/src/Struct/Statistic/FormStatisticInterface.php
+++ b/src/Struct/Statistic/FormStatisticInterface.php
@@ -23,21 +23,29 @@ interface FormStatisticInterface extends StructInterface
 
     /**
      * @return string
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getUrl(): string;
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getTypeId(): int;
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getFolderId(): int;
 
     /**
      * @return int
+     *
+     * @deprecated Not supported in specialized method, please use `getById`
      */
     public function getMandatorId(): int;
 


### PR DESCRIPTION
Several methods in FormStatistic are not supposed to work as they
provide extended resource information we dont' provide via api.
Add some sane defaults and deprecate the methods so we can remove them
within the next major update.

Also update the docs