### PR TITLE
Add new mailing properties

### DIFF
--- a/contrib/ReadmeGenerator.php
+++ b/contrib/ReadmeGenerator.php
@@ -111,7 +111,8 @@ final class ReadmeGenerator
         $lines .= $title . '(' . PHP_EOL;
         foreach ($reflector->getParameters() as $param) {
             $lines .= "    " . $param->getType()->getName();
-            if ($param->isArray()) {
+            /** @var ReflectionParameter $param */
+            if ($param->getType()->getName() === 'array') {
                 $docBlock = $reflector->getDocComment();
                 $matches = [];
                 if (preg_match('/@param ([a-z]*)\[\] \$/i', $docBlock, $matches)) {
@@ -155,6 +156,7 @@ $readmeDocumentStruct = new ReadmeDocument(
         'Scn\EvalancheSoapStruct\Struct\Form',
         'Scn\EvalancheSoapStruct\Struct\Generic',
         'Scn\EvalancheSoapStruct\Struct\Mailing',
+        'Scn\EvalancheSoapStruct\Struct\MailingTemplate',
         'Scn\EvalancheSoapStruct\Struct\Mandator',
         'Scn\EvalancheSoapStruct\Struct\Marketplace',
         'Scn\EvalancheSoapStruct\Struct\Pool',

--- a/docs/index.md
+++ b/docs/index.md
@@ -354,6 +354,10 @@ MailingConfiguration(
     string <htmlarea7>
     string <htmlarea8>
     string <htmlarea9>
+    string <revokeTrackingUrl>
+    string <grantTrackingUrl>
+    string <revokeConfirmationUrl>
+    bool <revokeConfirmationActive>
 )
 ```
 ##### MailingDetail
@@ -442,6 +446,75 @@ Represents a combination of a specific TargetGroup id and a specific subject tex
 MailingSubject(
     int <targetGroupId>
     string <subject>
+)
+```
+### MailingTemplate
+##### MailingTemplateConfiguration
+Contains information about the configuration of a specific mailing template<br>
+  like campaign id, individual salutations, reply address, input fields, etc.
+```
+MailingTemplateConfiguration(
+    string <externalTrackingCode>
+    string <campaignId>
+    string <externalXmlUrl>
+    string <salutationFemale>
+    string <salutationMale>
+    string <salutationCompany>
+    string <salutationFamily>
+    string <salutationOther>
+    string <senderEmail>
+    string <senderName>
+    string <replyName>
+    string <replyEmail>
+    string <grantUrl>
+    string <revokeUrl>
+    string <inputfield0>
+    string <inputfield1>
+    string <inputfield2>
+    string <inputfield3>
+    string <inputfield4>
+    string <inputfield5>
+    string <inputfield6>
+    string <inputfield7>
+    string <inputfield8>
+    string <inputfield9>
+    string <textarea0>
+    string <textarea1>
+    string <textarea2>
+    string <textarea3>
+    string <textarea4>
+    string <textarea5>
+    string <textarea6>
+    string <textarea7>
+    string <textarea8>
+    string <textarea9>
+    string <htmlarea0>
+    string <htmlarea1>
+    string <htmlarea2>
+    string <htmlarea3>
+    string <htmlarea4>
+    string <htmlarea5>
+    string <htmlarea6>
+    string <htmlarea7>
+    string <htmlarea8>
+    string <htmlarea9>
+    string <containerType>
+    string <salutationDivers>
+    string <revokeTrackingUrl>
+    string <grantTrackingUrl>
+    string <revokeConfirmationUrl>
+    bool <revokeConfirmationActive>
+)
+```
+##### MailingTemplatesSources
+Contains the source code of the mailing views
+```
+MailingTemplatesSources(
+    string <templateEmail>
+    string <templateText>
+    string <templateWeb>
+    string <templatePdf>
+    string <templateLandingpage>
 )
 ```
 ### Mandator

--- a/src/Struct/Mailing/MailingConfiguration.php
+++ b/src/Struct/Mailing/MailingConfiguration.php
@@ -82,6 +82,18 @@ class MailingConfiguration implements MailingConfigurationInterface
      */
     protected $grantUrl;
 
+    /** @var string */
+    protected $grantTrackingUrl;
+
+    /** @var string */
+    protected $revokeTrackingUrl;
+
+    /** @var string */
+    protected $revokeConfirmationUrl;
+
+    /** @var bool */
+    protected $revokeConfirmationActive;
+
     /**
      * @var string
      */
@@ -283,6 +295,10 @@ class MailingConfiguration implements MailingConfigurationInterface
      * @param string $htmlarea7
      * @param string $htmlarea8
      * @param string $htmlarea9
+     * @param string $grantTrackingUrl
+     * @param string $revokeTrackingUrl
+     * @param string $revokeConfirmationUrl
+     * @param bool $revokeConfirmationActive
      */
     public function __construct(
         string $externalTrackingCode = null,
@@ -329,7 +345,11 @@ class MailingConfiguration implements MailingConfigurationInterface
         string $htmlarea6 = null,
         string $htmlarea7 = null,
         string $htmlarea8 = null,
-        string $htmlarea9 = null
+        string $htmlarea9 = null,
+        string $revokeTrackingUrl = null,
+        string $grantTrackingUrl = null,
+        string $revokeConfirmationUrl = null,
+        bool $revokeConfirmationActive = false
     ) {
         $this->externalTrackingCode = $externalTrackingCode;
         $this->campaignId = $campaignId;
@@ -376,6 +396,10 @@ class MailingConfiguration implements MailingConfigurationInterface
         $this->htmlarea7 = $htmlarea7;
         $this->htmlarea8 = $htmlarea8;
         $this->htmlarea9 = $htmlarea9;
+        $this->grantTrackingUrl = $grantTrackingUrl;
+        $this->revokeTrackingUrl = $revokeTrackingUrl;
+        $this->revokeConfirmationUrl = $revokeConfirmationUrl;
+        $this->revokeConfirmationActive = $revokeConfirmationActive;
     }
 
     /**
@@ -660,6 +684,82 @@ class MailingConfiguration implements MailingConfigurationInterface
     public function setRevokeUrl(string $revokeUrl): MailingConfiguration
     {
         $this->revokeUrl = $revokeUrl;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGrantTrackingUrl(): string
+    {
+        return $this->grantTrackingUrl;
+    }
+
+    /**
+     * @param string $grantTrackingUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setGrantTrackingUrl(string $grantTrackingUrl): MailingConfiguration
+    {
+        $this->grantTrackingUrl = $grantTrackingUrl;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRevokeTrackingUrl(): string
+    {
+        return $this->revokeTrackingUrl;
+    }
+
+    /**
+     * @param string $revokeTrackingUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeTrackingUrl(string $revokeTrackingUrl): MailingConfiguration
+    {
+        $this->revokeTrackingUrl = $revokeTrackingUrl;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRevokeConfirmationUrl(): string
+    {
+        return $this->revokeConfirmationUrl;
+    }
+
+    /**
+     * @param string $revokeConfirmationUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeConfirmationUrl(string $revokeConfirmationUrl): MailingConfiguration
+    {
+        $this->revokeConfirmationUrl = $revokeConfirmationUrl;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getRevokeConfirmationActive(): bool
+    {
+        return $this->revokeConfirmationActive;
+    }
+
+    /**
+     * @param bool $revokeConfirmationActive
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeConfirmationActive(bool $revokeConfirmationActive): MailingConfiguration
+    {
+        $this->revokeConfirmationActive = $revokeConfirmationActive;
         return $this;
     }
 

--- a/src/Struct/Mailing/MailingConfigurationInterface.php
+++ b/src/Struct/Mailing/MailingConfigurationInterface.php
@@ -182,6 +182,54 @@ interface MailingConfigurationInterface extends StructInterface
     /**
      * @return string
      */
+    public function getGrantTrackingUrl(): string;
+
+    /**
+     * @param string $grantTrackingUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setGrantTrackingUrl(string $grantTrackingUrl): MailingConfiguration;
+
+    /**
+     * @return string
+     */
+    public function getRevokeTrackingUrl(): string;
+
+    /**
+     * @param string $revokeTrackingUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeTrackingUrl(string $revokeTrackingUrl): MailingConfiguration;
+
+    /**
+     * @return string
+     */
+    public function getRevokeConfirmationUrl(): string;
+
+    /**
+     * @param string $revokeConfirmationUrl
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeConfirmationUrl(string $revokeConfirmationUrl): MailingConfiguration;
+
+    /**
+     * @return bool
+     */
+    public function getRevokeConfirmationActive(): bool;
+
+    /**
+     * @param bool $revokeConfirmationActive
+     *
+     * @return MailingConfiguration
+     */
+    public function setRevokeConfirmationActive(bool $revokeConfirmationActive): MailingConfiguration;
+
+    /**
+     * @return string
+     */
     public function getInputfield0(): string;
 
     /**

--- a/src/Struct/MailingTemplate/MailingTemplateConfiguration.php
+++ b/src/Struct/MailingTemplate/MailingTemplateConfiguration.php
@@ -63,6 +63,11 @@ class MailingTemplateConfiguration extends MailingConfiguration implements Maili
      * @param string $htmlarea8
      * @param string $htmlarea9
      * @param string $containerType
+     * @param string $salutationDivers
+     * @param string $grantTrackingUrl
+     * @param string $revokeTrackingUrl
+     * @param string $revokeConfirmationUrl
+     * @param bool $revokeConfirmationActive
      */
     public function __construct(
         string $externalTrackingCode = null,
@@ -109,7 +114,12 @@ class MailingTemplateConfiguration extends MailingConfiguration implements Maili
         string $htmlarea7 = null,
         string $htmlarea8 = null,
         string $htmlarea9 = null,
-        string $containerType = null
+        string $containerType = null,
+        string $salutationDivers = null,
+        string $revokeTrackingUrl = null,
+        string $grantTrackingUrl = null,
+        string $revokeConfirmationUrl = null,
+        bool $revokeConfirmationActive = false
     ) {
         parent::__construct(
             $externalTrackingCode,
@@ -120,6 +130,7 @@ class MailingTemplateConfiguration extends MailingConfiguration implements Maili
             $salutationCompany,
             $salutationFamily,
             $salutationOther,
+            $salutationDivers,
             $senderEmail,
             $senderName,
             $replyName,
@@ -155,7 +166,11 @@ class MailingTemplateConfiguration extends MailingConfiguration implements Maili
             $htmlarea6,
             $htmlarea7,
             $htmlarea8,
-            $htmlarea9
+            $htmlarea9,
+            $revokeTrackingUrl,
+            $grantTrackingUrl,
+            $revokeConfirmationUrl,
+            $revokeConfirmationActive
         );
         $this->containerType = $containerType;
     }

--- a/tests/Struct/Mailing/MailingConfigurationTest.php
+++ b/tests/Struct/Mailing/MailingConfigurationTest.php
@@ -141,6 +141,37 @@ class MailingConfigurationTest extends StructTestCase
         );
     }
 
+    public function testGetGrantTrackingUrlCanReturnString(): void
+    {
+        $this->assertSame(
+            'some grant tracking url',
+            $this->subject->setGrantTrackingUrl('some grant tracking url')->getGrantTrackingUrl()
+        );
+    }
+
+    public function testGetRevokeTrackingUrlCanReturnString(): void
+    {
+        $this->assertSame(
+            'some revoke tracking url',
+            $this->subject->setRevokeTrackingUrl('some revoke tracking url')->getRevokeTrackingUrl()
+        );
+    }
+
+    public function testGetRevokeConfirmationUrlCanReturnString(): void
+    {
+        $this->assertSame(
+            'some revoke confirmation url',
+            $this->subject->setRevokeConfirmationUrl('some revoke confirmation url')->getRevokeConfirmationUrl()
+        );
+    }
+
+    public function testGetRevokeConfirmationActiveReturnsValue(): void
+    {
+        $this->assertTrue(
+            $this->subject->setRevokeConfirmationActive(true)->getRevokeConfirmationActive()
+        );
+    }
+
     public function testGetInputfield0CanReturnString()
     {
         $this->assertSame(


### PR DESCRIPTION
This add support for the following new properties:
- grant tracking url
- revoke tracking url
- revoke confirmation url
- revoke confirmation active

Also:
- Fix missing salutation `divers` in MailingTemplate
- Update ReadmeGenerator to remove deprecation warning
- Add `MailingTemplate` to readme generation

Fixes #63